### PR TITLE
Saving time and resources when list reload in Library

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/Constants.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/Constants.java
@@ -102,4 +102,6 @@ public final class Constants {
     public static final String EXTRA_WEBVIEWS_LIST = "webviewsList";
 
     public static final String EXTRA_BOOKMARK_CONTENTS = "bookmark_contents";
+
+    public static final String EXTRA_BOOKS_ONLINE = "books_online";
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.java
@@ -14,6 +14,8 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
@@ -60,6 +62,7 @@ import static android.view.View.GONE;
 import static org.kiwix.kiwixmobile.downloader.DownloadService.KIWIX_ROOT;
 import static org.kiwix.kiwixmobile.library.entity.LibraryNetworkEntity.Book;
 import static org.kiwix.kiwixmobile.utils.Constants.EXTRA_BOOK;
+import static org.kiwix.kiwixmobile.utils.Constants.EXTRA_BOOKS_ONLINE;
 import static org.kiwix.kiwixmobile.utils.Constants.PREF_STORAGE;
 import static org.kiwix.kiwixmobile.utils.Constants.PREF_STORAGE_TITLE;
 
@@ -87,7 +90,7 @@ public class LibraryFragment extends Fragment
   LibraryPresenter presenter;
   private NetworkBroadcastReceiver networkBroadcastReceiver;
   private boolean isReceiverRegistered = false;
-  private ArrayList<Book> books = new ArrayList<>();
+  private LinkedList<Book> books;
   private boolean mBound;
   private DownloadServiceConnection mConnection = new DownloadServiceConnection();
   private ZimManageActivity faActivity;
@@ -136,16 +139,13 @@ public class LibraryFragment extends Fragment
       displayNoItemsAvailable();
       return;
     }
-
+    this.books = books;
     Log.i("kiwix-showBooks", "Contains:" + books.size());
     libraryAdapter.setAllBooks(books);
-    if (faActivity.searchView != null) {
-      libraryAdapter.getFilter().filter(
-          faActivity.searchView.getQuery(),
-          i -> stopScanningContent());
-    } else {
-      libraryAdapter.getFilter().filter("", i -> stopScanningContent());
-    }
+
+    String query = (faActivity.searchView != null) ? faActivity.searchView.getQuery().toString() : "";
+    libraryAdapter.getFilter().filter(query, i -> stopScanningContent());
+
     libraryAdapter.notifyDataSetChanged();
     libraryList.setOnItemClickListener(this);
   }
@@ -326,6 +326,21 @@ public class LibraryFragment extends Fragment
       editor.putString(PREF_STORAGE_TITLE, getResources().getString(R.string.external_storage));
     }
     editor.apply();
+  }
+
+  @Override
+  public void onSaveInstanceState(@NonNull Bundle outState) {
+    super.onSaveInstanceState(outState);
+    outState.putSerializable(EXTRA_BOOKS_ONLINE, books);
+  }
+
+  @Override
+  public void onViewStateRestored(@Nullable Bundle savedInstanceState) {
+    super.onViewStateRestored(savedInstanceState);
+    if ((savedInstanceState != null && savedInstanceState.containsKey(EXTRA_BOOKS_ONLINE))) {
+      books = (LinkedList<Book>) savedInstanceState.getSerializable(EXTRA_BOOKS_ONLINE);
+      showBooks(books);
+    }
   }
 
   public class DownloadServiceConnection {


### PR DESCRIPTION
Fixes This is an improvement commented in #538 by @GeVic.

Changes: Use Fragment methods onSaveInstanceState and onViewStateRestored to reload the books so now the app don't use Internet every time the user rotates the device and as you can see on the GIF the reload is quite faster.

Screenshots/GIF for the change: [If possible, please add relevant screenshots/GIF]

![](https://media.giphy.com/media/55tELYEheb1GAf4MgV/giphy.gif)
